### PR TITLE
Fix for website action

### DIFF
--- a/websiteaction/src/main/java/com/stream_pi/websiteaction/WebsiteAction.java
+++ b/websiteaction/src/main/java/com/stream_pi/websiteaction/WebsiteAction.java
@@ -46,7 +46,27 @@ public class WebsiteAction extends NormalAction
 
         try
         {
-            Desktop.getDesktop().browse(new URI(urlToOpen));
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE))
+            {
+                Desktop.getDesktop().browse(new URI(urlToOpen));
+            }
+            else
+            {
+                Runtime runtime = Runtime.getRuntime();
+                String osName = System.getProperty("os.name").toLowerCase();
+                if (osName.contains("mac"))
+                {
+                    runtime.exec("open " + urlToOpen);
+                }
+                else if (osName.contains("nix") || osName.contains("nux"))
+                {
+                    runtime.exec("xdg-open " + urlToOpen);
+                }
+                else
+                {
+                    throw new MinorException("Unable to open URL '"+urlToOpen+"'. Check if its correct.");
+                }
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Fixed website action not working on Unix/Linux and macOS devices if they do not support Desktop class or the Action "BROWSE" of the Desktop class.

As a workaround the command "open" is used on macOS and the command "xdg-open" is used on Unix/Linux to open the requested url.